### PR TITLE
Rename strip_whitespace -> strip_whitespace_from

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ being stripped as expected.
 
 **AR Models:**
 
-Just call `strip_whitespace` in your model class, passing one or more attributes
+Just call `strip_whitespace_from` in your model class, passing one or more attributes
 you want stripped of leading and trailing whitespace. Striptease does this in a
 `before_validation` hook.
 
 ```rb
 class SomeClass < ActiveRecord::Base
-  strip_whitespace :foo, :bar
+  strip_whitespace_from :foo, :bar
 end
 ```
 

--- a/lib/striptease.rb
+++ b/lib/striptease.rb
@@ -9,10 +9,13 @@ module Striptease
     end
   end
 
-  def strip_whitespace(*attributes)
+  def strip_whitespace_from(*attributes)
     self.strippable_attributes = attributes
     before_validation :_strip_whitespace
   end
+
+  # NOTE: for backwards compatability, remove in next major version bump
+  alias_method :strip_whitespace, :strip_whitespace_from
 
   module InstanceMethods
     private

--- a/spec/striptease_spec.rb
+++ b/spec/striptease_spec.rb
@@ -6,31 +6,61 @@ ActiveRecord::Base.establish_connection(
 )
 
 describe Striptease do
-  context '.strip_whitespace' do
-    class Record < ActiveRecord::Base
-      strip_whitespace :foo, :bar
+  around(:each) do |example|
+    ActiveRecord::Schema.define do
+      create_table :records do |table|
+        table.column :foo, :string
+        table.column :bar, :string
+        table.column :baz, :string
+      end
     end
 
-    around(:each) do |example|
-      ActiveRecord::Schema.define do
-        create_table :records do |table|
-          table.column :foo, :string
-          table.column :bar, :string
-          table.column :baz, :string
+    example.run
+
+    ActiveRecord::Schema.define { drop_table :records }
+  end
+
+  context '.strip_whitespace' do
+    before { class Record < ActiveRecord::Base; end  }
+
+    it 'delegates to .strip_whitespace_from' do
+      expect(Record.strip_whitespace).to eq(Record.strip_whitespace_from)
+    end
+  end
+
+  context '.strip_whitespace_from' do
+    context 'when there are no format validations on the attributes' do
+      before do
+        class Record < ActiveRecord::Base
+          strip_whitespace_from :foo, :bar
         end
       end
 
-      example.run
+      it 'strips whitespace from specified attributes' do
+        record = Record.create!(foo: ' foo ', bar: ' bar ', baz: ' baz ')
 
-      ActiveRecord::Schema.define { drop_table :records }
+        expect(record.foo).to eq('foo')
+        expect(record.bar).to eq('bar')
+        expect(record.baz).to eq(' baz ')
+      end
     end
 
-    it 'strips whitespace from specified attributes' do
-      record = Record.create!(foo: ' foo ', bar: ' bar ', baz: ' baz ')
+    context 'when there are format validations on the attributes' do
+      before do
+        class Record < ActiveRecord::Base
+          strip_whitespace_from :foo, :bar
+          validates :foo, format: /[a-z]/
+          validates :bar, inclusion: %w(this that)
+        end
+      end
 
-      expect(record.foo).to eq('foo')
-      expect(record.bar).to eq('bar')
-      expect(record.baz).to eq(' baz ')
+      it 'strips whitespace from specified attributes' do
+        record = Record.create!(foo: ' abc ', bar: ' this ', baz: ' baz ')
+
+        expect(record.foo).to eq('abc')
+        expect(record.bar).to eq('this')
+        expect(record.baz).to eq(' baz ')
+      end
     end
   end
 end


### PR DESCRIPTION
**BECAUSE:**

* Our AR model class method was `strip_whitespace` and our rspec matcher was `strip_whitespace_from`

**THIS PR:**

* Renames `strip_whitespace` to `strip_whitespace_from` (and aliases for backwards compatibility since this isn't a major version bump)
* Explicitly adds coverage for formatted validations in AR models
* Bumps the minor version number 
* Updates the README